### PR TITLE
2024 5 7 tk fix drag drop centering

### DIFF
--- a/app/src/view/RackItem.svelte
+++ b/app/src/view/RackItem.svelte
@@ -42,7 +42,6 @@ import { RackItem } from "../model/rack-item";
     })();
 
     item.on('move', ({ x: X, y: Y}) => {
-        console.log('move', X, Y);
         x: x = X;
         y = Y;
     });


### PR DESCRIPTION
I removed some console.logs and made it so dragging measured from the center of the item rather than the corner.

I solved this using a bad method that could potentially introduce a bug, but I couldn't figure out a better way to do it. On the last move event, the "y" variable on line 47 of index.ts is exactly the height of the item, causing it to jump around weirdly. I added a 50px threshold (the item is 380px) so if it jumps over 50px, it resets to the previous value. Theoretically, dx/dy values should be within 5px of each other, with the exception if they drag the item off the screen then back on.