### PR TITLE
30 fps and use own event loop

### DIFF
--- a/app/src/utils/contextmenu.ts
+++ b/app/src/utils/contextmenu.ts
@@ -118,5 +118,5 @@ export const contextmenu = (
         document.addEventListener('click', rm);
     };
 
-    target.addEventListener('contextmenu', fn);
+    // target.addEventListener('contextmenu', fn);
 };


### PR DESCRIPTION
Used requestAnimationFrame and a 30fps loop to force cables to be on a separate loop than the interactjs.io's loop which relies on mousemove. This way, it only renders at 30fps instead of every single time the mouse moves.